### PR TITLE
Add X-Forwarded-For and X-Frame-Options header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY entrypoint.sh /entrypoint.sh
 COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY ssl.pem /etc/ssl/private/ssl.pem
 
+# make entrypoint executable
+RUN chmod 500 /entrypoint.sh
+
 # expose ports
 EXPOSE 80 81 82 83 443
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ docker run -d travix/haproxy:latest
 
 In order to configure the haproxy load balancer for providing ssl on port 443 for your gocd server you can use the following environment variables
 
-| Name                 | Description                                                               | Default value |
-| -------------------- | ------------------------------------------------------------------------- | ------------- |
-| OFFLOAD_TO_PORT      | The http port the actual application inside the Kubernetes pod listens to | 5000          |
-| SSL_CERTIFICATE_NAME | The pem filename for the ssl certificate used on port 443                 | ssl.pem       |
-| X_FRAME_OPTIONS      | X-Frame-Options header value                                              | DENY          |
+| Name                   | Description                                                               | Default value   |
+| ---------------------- | ------------------------------------------------------------------------- | --------------- |
+| OFFLOAD_TO_PORT        | The http port the actual application inside the Kubernetes pod listens to | 5000            |
+| SSL_CERTIFICATE_NAME   | The pem filename for the ssl certificate used on port 443                 | ssl.pem         |
+| X_FORWARDED_FOR_HEADER | X-Forwarded-For header value to check                                     | X-Forwarded-For |
+| X_FRAME_OPTIONS        | X-Frame-Options header value                                              | DENY            |
 
 ```sh
 docker run -d \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+sed -i -e "s#X-Frame-Options: DENY#X-Frame-Options: ${X_FRAME_OPTIONS}#" /etc/haproxy/haproxy.cfg
+sed -i -e "s/directhostname/${DIRECT_HOST_NAME}/" /etc/haproxy/haproxy.cfg
+sed -i -e "s/localhost:5000/${OFFLOAD_TO_HOST}:${OFFLOAD_TO_PORT}/" /etc/haproxy/haproxy.cfg
+sed -i -e "s/option httpchk HEAD/option httpchk ${HEALT_CHECK_VERB}/" /etc/haproxy/haproxy.cfg
+sed -i -e "s/ssl.pem/${SSL_CERTIFICATE_NAME}/" /etc/haproxy/haproxy.cfg
+sed -i -e "s:(X-Forwarded-For):(${X_FORWARDED_FOR_HEADER}):" /etc/haproxy/haproxy.cfg
+sed -i -e "s:/healthz:${HEALT_CHECK_PATH}:" /etc/haproxy/haproxy.cfg
+sed -i -e "s:TLS_SETTINGS:${TLS_SETTINGS}:" /etc/haproxy/haproxy.cfg
+sed -i -e "s:WHITELIST_CIDRS:${WHITELIST_CIDRS}:" /etc/haproxy/haproxy.cfg
+sed -i -e "s:stats refresh 5s:stats refresh ${STATS_REFRESH_INTERVAL}:" /etc/haproxy/haproxy.cfg
+sed -i -e "s:statspassword:${STATS_PASSWORD}:" /etc/haproxy/haproxy.cfg
+
+exec "$@"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -49,7 +49,7 @@ frontend http-in
 frontend https-in
   bind *:443 ssl crt /etc/ssl/private/ssl.pem ciphers AES128+EECDH:AES128+EDH TLS_SETTINGS
   rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubdomains;\ preload
-  rspadd X-Frame-Options:\ DENY
+  reqirep X-Frame-Options:\ (.*) X-Frame-Options:\ DENY
 
   # whitelist ip addresses in X-Forwarded-For header if the header exists or src otherwise
   acl has_xforwardedfor_header hdr(X-Forwarded-For) -m found


### PR DESCRIPTION
Add possibility to use different __X-Forwarded-For__ header name and replace __X-Frame-Options__.

`X-Forwarded-For` is quite useful, in a case of having HAProxy behind CloudFlare we can set `X_FORWARDED_FOR_HEADER=True-Client-IP`.

`rspadd` was replaced by `reqirep` to prevent double header if `X-Frame-Options` is already defined by the backend.